### PR TITLE
Bug when triggering omnicompletion on lines with neither a "(" nor a "."

### DIFF
--- a/autoload/vaxe.vim
+++ b/autoload/vaxe.vim
@@ -140,7 +140,7 @@ function! vaxe#HaxeComplete(findstart,base)
        let period = strridx(line, '.')
        let paren = strridx(line, '(')
        if (period == paren)
-           return -1;
+           return -1
        endif
        let basecol = max([period,paren]) + 1
        return basecol


### PR DESCRIPTION
When I press ^X ^O on a line without a opening parenthesis nor a punctuation mark I get the following error message:

```
Error detected while processing function vaxe#HaxeComplete:
line    6:
E15: Invalid expression: -1;
```

I don't really know Vimscript, but as far as I can see the bug is caused by a misplaced semicolon which this patch removes.
