### PR TITLE
Additional round brackets escaping for completion compiler call

### DIFF
--- a/autoload/vaxe.vim
+++ b/autoload/vaxe.vim
@@ -447,7 +447,7 @@ function! s:SanitizeHxml(complete_string)
         let p = substitute(p, '^\s*-\(cmd\|xml\|v\|-times\)\s*.*', '', '')
 
         " fnameescape directives
-        let p = substitute(p, '^\s*\(--\?[a-z0-9\-]\+\)\s*\(.*\)$', '\=submatch(1)." ".fnameescape(submatch(2))', '')
+        let p = substitute(p, '^\s*\(--\?[a-z0-9\-]\+\)\s*\(.*\)$', '\=submatch(1)." ".escape(fnameescape(submatch(2)), "()")', '')
 
         call add(fixed, p)
     endfor


### PR DESCRIPTION
Possible fix for an issue https://github.com/jdonaldson/vaxe/issues/21

I've wrapped the “fnnameespace” function call with additional “escape” function call to escape round brackets. I'm not an expert in vim script, so it may be the wrong way.
