### PR TITLE
Restore/fix EReg escape sequence highlighting

### DIFF
--- a/syntax/haxe.vim
+++ b/syntax/haxe.vim
@@ -113,8 +113,7 @@ syn match haxePreError "#error"
 " -----
 syn region haxeRegex start=+\~\/+ end=+\/+ contains=haxeRegexEscape,haxeRegexError,@Spell
 
-" Order is important here. The second line selectively overrides the first.
-syn match haxeRegexError contained "\\."
+syn match haxeRegexError contained "\\[^0-9bdnrstwxBDSW(){}\[\]\\$^*\-+|./?]"
 syn match haxeRegexEscape contained "\\[0-9bdnrstwxBDSW(){}\[\]\\$^*\-+|./?]"
 
 " meta


### PR DESCRIPTION
The escape sequences used in the following code sample should all be valid Haxe EReg syntax. My changes highlight all of them as `haxeRegexEscape` and reject others as `haxeRegexError`.

``` haxe
package;

class ERegTest {
    public static function alphaTest() {
        var lower = ~/\b\d\n\r\s\t\w\x/;
        var upper = ~/\B\D\S\W/;
    }

    public static function numTest() {
        var test = ~/\1\2\3\4\5\6\7\8\9\0/;
    }

    public static function punctTest() {
        var balanced = ~/\(\)\[\]\{\}/;
        var numkeys = ~/\$\^\*\-\+/;
        var etc = ~/\\\|\.\/\?/;
    }

    public static function main() {
        trace("Syntax checks out");
    }
}
```

I began by generating every possible (single-character) escape sequence I could think of, and removing the ones that produced errors. I've tried the remaining code on a variety of compilation targets and have not found any for which this syntax is invalid. I have _not_ confirmed whether these escape sequences have uniform cross-platform semantics, or whether there is _any_ valid use case for all of the sequences my patch describes. My investigation has strictly been one of syntax. I'll leave it to the maintainers to decide whether further investigation is called for.

This patch does not interfere with the existing behavior of `haxeString` or `haxeSString`, where various escape sequences are highlighted as errors. I will issue a separate patch that makes small modifications to that behavior, thus closing issue #29.
