### PR TITLE
fixed a problem in which write events would be ignored after omnicompletion

### DIFF
--- a/autoload/vaxe.vim
+++ b/autoload/vaxe.vim
@@ -556,7 +556,7 @@ function! s:HandleWriteEvent()
     if (g:vaxe_completion_prevent_bufwrite_events)
         let events = "BufWritePost,BufWritePre,BufWriteCmd"
     endif
-    let &l:eventignore = old_ignore
+
     if (&l:eventignore)
         let &l:eventignore = &l:eventignore . ',' . events
     else
@@ -569,6 +569,7 @@ function! s:HandleWriteEvent()
         exe ":silent update"
     endif
 
+    let &l:eventignore = old_ignore
 endfunction
 
 " a 'raw completion' function that will just return unformatted output

--- a/doc/vaxe.txt
+++ b/doc/vaxe.txt
@@ -393,7 +393,7 @@ SETTINGS                                        *vaxe-settings*
                         Defaults to 0 (equivalent to always adding --no-output
                         in the hxml).
 
-*g:vaxe_completion_completion_bufwrite_events*
+*g:vaxe_completion_prevent_bufwrite_events*
                         Vaxe uses the compiler to make completions.  This can
                         happen frequently, and causes the buffer to be written.
                         This can in turn interfere with other scripts that


### PR DESCRIPTION
I noticed that automatic Syntastic checking would stop working after
performing an omnicompletion if
g:vaxe_completion_prevent_bufwrite_events was enabled. This was because
the s:HandleWriteEvent function wasn't reverting l:eventignore to its
original value after it's done.

I also corrected a typo in line 396 of the documentation.