### PR TITLE
Fix autocompletion for Windows (closes #78)

### DIFF
--- a/autoload/vaxe.vim
+++ b/autoload/vaxe.vim
@@ -584,7 +584,12 @@ function! s:RawCompletion(vaxe_hxml, extra_string)
     let complete_args = s:CompletionHxml(expand("%:p"), offset)
     let complete_args = complete_args . ' ' . a:extra_string
 
-    let hxml_cd = "cd\ \"".fnamemodify(a:vaxe_hxml,":p:h"). "\";"
+    let hxml_cd = "cd\ \"".fnamemodify(a:vaxe_hxml,":p:h"). "\""
+    if has('win32')
+        let hxml_cd = hxml_cd. "&"
+    else
+        let hxml_cd = hxml_cd. ";"
+    endif
     if exists("g:vaxe_hxml")
         let hxml_cd = ''
     endif


### PR DESCRIPTION
I'm not very familiar with VimL, but this seems to work on my Windows machine. Please test on Unix.

BTW, why doesn't it just use haxe's own `--cwd` argument?