### PR TITLE
Work around Neovim bug by using script-local funcref

### DIFF
--- a/plugin/haxe.vim
+++ b/plugin/haxe.vim
@@ -60,57 +60,57 @@ let g:tagbar_type_haxe = {
     \ }
 
 " a short alias, since I use this all over the place
-let C = function("vaxe#util#Config")
+let s:c = function("vaxe#util#Config")
 
 " misc options
-let g:vaxe_haxe_version        = C('g:vaxe_haxe_version', 3)
-let g:vaxe_cache_server        = C('g:vaxe_cache_server', 0)
-let g:vaxe_logging             = C('g:vaxe_logging', 0)
-let g:vaxe_trace_absolute_path = C('g:vaxe_trace_absolute_path', 1)
+let g:vaxe_haxe_version        = s:c('g:vaxe_haxe_version', 3)
+let g:vaxe_cache_server        = s:c('g:vaxe_cache_server', 0)
+let g:vaxe_logging             = s:c('g:vaxe_logging', 0)
+let g:vaxe_trace_absolute_path = s:c('g:vaxe_trace_absolute_path', 1)
 
 " completion options
 let g:vaxe_completion_require_autowrite
-            \=C('g:vaxe_require_completion_autowrite', 1)
+            \= s:c('g:vaxe_require_completion_autowrite', 1)
 let g:vaxe_completion_disable_optimizations
-            \= C('g:vaxe_completion_disable_optimizations', 1)
+            \= s:c('g:vaxe_completion_disable_optimizations', 1)
 let g:vaxe_completion_alter_signature
-            \= C('g:vaxe_completion_alter_signature', 1)
+            \= s:c('g:vaxe_completion_alter_signature', 1)
 let g:vaxe_completion_collapse_overload
-            \= C('g:vaxe_completion_collapse_overload', 0)
+            \= s:c('g:vaxe_completion_collapse_overload', 0)
 let g:vaxe_completion_write_compiler_output
-            \= C('g:vaxe_completion_write_compiler_output', 0)
+            \= s:c('g:vaxe_completion_write_compiler_output', 0)
 let g:vaxe_completion_prevent_bufwrite_events
-            \= C('g:vaxe_completion_prevent_bufwrite_events',1)
+            \= s:c('g:vaxe_completion_prevent_bufwrite_events',1)
 let g:vaxe_completeopt_menuone
-            \= C('g:vaxe_completeopt_menuone', 1)
+            \= s:c('g:vaxe_completeopt_menuone', 1)
 
 " cache server options
-let g:vaxe_cache_server_port      = C('g:vaxe_cache_server_port', 6878)
-let g:vaxe_cache_server_autostart = C('g:vaxe_cache_server_autostart', 1)
+let g:vaxe_cache_server_port      = s:c('g:vaxe_cache_server_port', 6878)
+let g:vaxe_cache_server_autostart = s:c('g:vaxe_cache_server_autostart', 1)
 
 " lime options
-let g:vaxe_lime_test_on_build     = C('g:vaxe_lime_test_on_build', 1)
-let g:vaxe_lime_target            = C('g:vaxe_lime_target',"")
-let g:vaxe_lime_completion_target = C('g:vaxe_lime_completion_target', 'flash')
+let g:vaxe_lime_test_on_build     = s:c('g:vaxe_lime_test_on_build', 1)
+let g:vaxe_lime_target            = s:c('g:vaxe_lime_target',"")
+let g:vaxe_lime_completion_target = s:c('g:vaxe_lime_completion_target', 'flash')
 
 " flow options
-let g:vaxe_flow_target            = C('g:vaxe_flow_target', "")
-let g:vaxe_flow_completion_target = C('g:vaxe_flow_completion_target', 'web')
+let g:vaxe_flow_target            = s:c('g:vaxe_flow_target', "")
+let g:vaxe_flow_completion_target = s:c('g:vaxe_flow_completion_target', 'web')
 
 " default build options
-let g:vaxe_prefer_hxml               = C('g:vaxe_prefer_hxml', "build.hxml")
-let g:vaxe_prefer_lime               = C('g:vaxe_prefer_lime', "*.lime")
-let g:vaxe_prefer_flow               = C('g:vaxe_prefer_flow', "*.flow")
-let g:vaxe_prefer_openfl             = C('g:vaxe_prefer_openfl', "project.xml")
-let g:vaxe_prefer_first_in_directory = C('g:vaxe_prefer_first_in_directory', 1)
+let g:vaxe_prefer_hxml               = s:c('g:vaxe_prefer_hxml', "build.hxml")
+let g:vaxe_prefer_lime               = s:c('g:vaxe_prefer_lime', "*.lime")
+let g:vaxe_prefer_flow               = s:c('g:vaxe_prefer_flow', "*.flow")
+let g:vaxe_prefer_openfl             = s:c('g:vaxe_prefer_openfl', "project.xml")
+let g:vaxe_prefer_first_in_directory = s:c('g:vaxe_prefer_first_in_directory', 1)
 let g:vaxe_default_parent_search_patterns
-            \= C('g:vaxe_default_parent_search_patterns'
+            \= s:c('g:vaxe_default_parent_search_patterns'
             \, [g:vaxe_prefer_lime, g:vaxe_prefer_flow, g:vaxe_prefer_openfl, g:vaxe_prefer_hxml, "*.hxml"])
 
 " Supported 3rd party plugin options
-let g:vaxe_enable_airline_defaults = C('g:vaxe_enable_airline_defaults', 1)
-let g:vaxe_enable_ycm_defaults     = C('g:vaxe_enable_ycm_defaults', 1)
-let g:vaxe_enable_acp_defaults     = C('g:vaxe_enable_acp_defaults', 1)
+let g:vaxe_enable_airline_defaults = s:c('g:vaxe_enable_airline_defaults', 1)
+let g:vaxe_enable_ycm_defaults     = s:c('g:vaxe_enable_ycm_defaults', 1)
+let g:vaxe_enable_acp_defaults     = s:c('g:vaxe_enable_acp_defaults', 1)
 
 if !exists('g:vaxe_haxe_binary')
 	let g:vaxe_haxe_binary = 'haxe'


### PR DESCRIPTION
Neovim has a bug that breaks shared-data saving when a funcref is stored in a capitalized variable (see neovim/neovim#3721). The workaround is to use a script-local variable instead.

Warning: I haven't actually tested this commit, except to verify that the plugin loads cleanly and it fixes the Neovim issue for me.
