### PR TITLE
Fix ","' in search path

### DIFF
--- a/autoload/vaxe/util.vim
+++ b/autoload/vaxe/util.vim
@@ -7,13 +7,14 @@ function! vaxe#util#ParentSearch(patterns, dir)
     let last_dir = ''
     while(current_dir != last_dir)
         let last_dir = current_dir
+        let current_dir = join(split(current_dir, ","), "\\,")
         for p in a:patterns
             let match = globpath(current_dir, p)
             if match != ''
                 return match
             endif
         endfor
-        let current_dir = fnamemodify(current_dir, ":p:h:h")
+        let current_dir = fnamemodify(last_dir, ":p:h:h")
     endwhile
     return ''
 endfunction


### PR DESCRIPTION
When trying out the sample from Lime, Vaxe was unable to find the "project.xml", after some digging, seems like "globpath" doesn't like "," in path.

Lime samples path in haxelib looks something like that
```
/home/starburst/haxelib/lime-samples/3,4,0/demos/BunnyMark
```

Simple fix to use "\," instead of "," in path.