### PR TITLE
Fixed haxeInterpolated

### DIFF
--- a/syntax/haxe.vim
+++ b/syntax/haxe.vim
@@ -88,8 +88,7 @@ syn match haxeErrorCharacter contained "\\\(x.\{0,2}\|u.\{0,4\}\|[^"'\\/nrt]\)"
 syn match haxeSpecialCharacter contained "\\\(x[a-fA-F0-9]\{2\}\|[0-7]\{3\}\|["'\\/nrt]\)"
 syn match haxeIntSpecialChar contained "\$\@<!\(\$\$\)\+\(\(\$\$\)\+\)\@!"
 syn match haxeInterpolatedIdent contained "\((\$\$)\+\)\@<!\$[a-zA-Z_][a-zA-Z_0-9]*"
-syn region haxeInterpolated contained start=+\((\$\$)\+\)\@<!\${+ end=+}+ contains=TOP
-syn region haxeInterpolated contained start=+\(\$\(\$\$\)\+\)\@<!${+ end=+}+ contains=TOP
+syn region haxeInterpolated contained start=+\(\$\(\$\$\)\+\)\@<!${+ end=+}+ contains=@Spell
 syn region haxeDString start=+"+ end=+"+ contains=haxeSpecialCharacter,haxeErrorCharacter,@Spell
 syn region haxeSString start=+'+ end=+'+ contains=haxeSpecialCharacter,haxeErrorCharacter,haxeIntSpecialChar,haxeInterpolatedIdent,haxeInterpolated,@Spell
 


### PR DESCRIPTION
Hello,

At this moment the following code is breaking the color syntax:
```haxe
trace('A string with foo : ${bar + 3}');
```
Current broken state :
![screenshot](https://user-images.githubusercontent.com/1249453/30438888-ab178a72-9972-11e7-8e5d-588937e4f0be.png)

With this PR:
![screenshot](https://user-images.githubusercontent.com/1249453/30438925-c3baea9c-9972-11e7-861a-41755c2f7486.png)

This is my first time digging into this code so I am not sure what `TOP` was. Also `haxeInterpolated` was defined twice.
