### PR TITLE
clarify package/class name regex in ImportClass()

### DIFF
--- a/autoload/vaxe.vim
+++ b/autoload/vaxe.vim
@@ -86,7 +86,7 @@ endfunction
 " You can also call this without a package prefix, and vaxe will try to look
 " up packages that contain the (e.g. FastList) class name.
 function! vaxe#ImportClass()
-   let match_parts = matchlist(getline('.'), '\(\(\l\+\.\)\+\)*\(\u\w*\)')
+   let match_parts = matchlist(getline('.'), '\W\(\(\l\+\.\)\+\)*\(\u\w*\)')
    if len(match_parts)
        let package = match_parts[1]
        " get rid of the period at the end of the package declaration.


### PR DESCRIPTION
Consider the following line of Haxe code:

    setFacingFlip(FlxObject.LEFT, false, false);

Assuming the `FlxObject` class was not imported, a compilation error would be thrown. One might want to call the `vaxe#ImportClass()` function to remedy this issue. However, the previous implementation of the regex would match `FacingFlip`, which is not the proper class name to search for in the ctags file.

In reality, package/class names must necessarily follow a non-word character in order to compile correctly. So, that constraint can be used to clarify the regex and more often guarantee a proper match.

I only started learning Haxe a few weeks ago, so my understanding of the syntax is probably very lacking. I'm sure that someone with more experience with the language might have a more appropriate fix.